### PR TITLE
Searching for disabled elements

### DIFF
--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -583,7 +583,7 @@ end
 # Tests that an input or button with the given label is disabled.
 Then /^the "([^\"]*)" (field|button) should( not)? be disabled$/ do |label, kind, negate|
   options = {}
-  options[:disabled] = true if negate
+  options[:disabled] = true unless negate
   page.should have_selector kind.to_sym, label, options
 end
 

--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -582,12 +582,9 @@ end
 
 # Tests that an input or button with the given label is disabled.
 Then /^the "([^\"]*)" (field|button) should( not)? be disabled$/ do |label, kind, negate|
-  if kind == 'field'
-    element = find_field(label)
-  else
-    element = find_button(label)
-  end
-  ["false", "", nil].send(negate ? :should : :should_not, include(element[:disabled]))
+  options = {}
+  options[:disabled] = true if negate
+  page.should have_selector kind.to_sym, label, options
 end
 
 # Tests that a field with the given label is visible.


### PR DESCRIPTION
Searching for disabled elements previously didn't work, see #18. Looks like we can now pass a `:disabled` option to `Capybara::Node::Matchers.has_selector?` method.