### PR TITLE
'Then debugger' Can Be Used With Pry

### DIFF
--- a/lib/spreewald/development_steps.rb
+++ b/lib/spreewald/development_steps.rb
@@ -5,9 +5,14 @@ Then /^it should work$/ do
   pending
 end
 
-# Starts debugger
+# Starts debugger, or Pry if installed
 Then /^debugger$/ do
-  debugger
+  if binding.respond_to? :pry
+    binding.pry
+  else
+    debugger
+  end
+
   true # Ruby will halt in this line
 end
 


### PR DESCRIPTION
Some people, like myself, prefer to use [Pry](http://rubygems.org/gems/pry) instead of ruby-debug. This change allows them to use the existing "Then debugger" step with Pry and not introduce any backwards incompatibilities along the way.
