### PR TITLE
Step To Support Docstring Format for Filling Forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,21 @@ deprecation notice. Decide for yourself whether you want to use them:
   Fill in text field
 
 
+* **When I fill in "..." (with|for)**
+
+  Fill in text field with multi-line block
+  You can use a doc string to supply multi-line text
+
+  Example:
+
+        When I fill in "some field" with
+        """
+        Apple
+        Banana
+        Pear
+        """
+
+
 * **When I fill in "..." (with|for) '...'**
 
   Fill in text field

--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -89,6 +89,23 @@ When /^(?:|I )fill in "([^"]*)" (?:with|for) "([^"]*)"$/ do |field, value|
   end
 end
 
+# Fill in text field with multi-line block
+# You can use a doc string to supply multi-line text
+#
+# Example:
+#
+#       When I fill in "some field" with
+#       """
+#       Apple
+#       Banana
+#       Pear
+#       """
+When /^(?:|I )fill in "([^"]*)" (?:with|for):$/ do |field, value|
+  patiently do
+    fill_in(field, :with => value)
+  end
+end
+
 # Fill in text field
 When /^(?:|I )fill in "([^"]*)" (?:with|for) '(.*)'$/ do |field, value|
   patiently do


### PR DESCRIPTION
Fixes #29 . This adds a step that will allow you to fill a text field with content specified as a doc string, e.g.:

```
I fill in "Colours" with:
  """
  Green
  Blue
  """
```

None of the other action steps seem to have tests, so I didn't do a test for this one. Let me know if I should.
