### PR TITLE
Remove Bad Symlink

### DIFF
--- a/tests/rails-3.2/capybara-2/log
+++ b/tests/rails-3.2/capybara-2/log
@@ -1,1 +1,0 @@
-../capybara-1/log


### PR DESCRIPTION
This resolves the following issue when building Spreewald:

```
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["tests/rails-3.2/capybara-2/log"] are not files
```

Supposing that this directory is supposed to exist I can amend this pull request accordingly.
