### PR TITLE
Make Spreewald Safer for RSpec 3

### DIFF
--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -1,6 +1,6 @@
 # coding: UTF-8
 
-# Most of cucumber-rails' original web steps plus a few of our own. 
+# Most of cucumber-rails' original web steps plus a few of our own.
 #
 # Note that cucumber-rails deprecated all its steps quite a while ago with the following
 # deprecation notice. Decide for yourself whether you want to use them:
@@ -267,7 +267,7 @@ Then /^the "([^"]*)" checkbox(?: within (.*))? should be checked$/ do |label, pa
   patiently do
     with_scope(parent) do
       field_checked = find_field(label)['checked']
-      field_checked.should be_true
+      field_checked.should eq(true)
     end
   end
 end
@@ -277,7 +277,7 @@ Then /^the "([^"]*)" checkbox(?: within (.*))? should not be checked$/ do |label
   patiently do
     with_scope(parent) do
       field_checked = find_field(label)['checked']
-      field_checked.should be_false
+      field_checked.should eq(true)
     end
   end
 end
@@ -477,8 +477,8 @@ Then /^(the tag )?"([^\"]+)" should( not)? be visible$/ do |tag, selector_or_tex
 
         })();
       ].gsub(/\n/, ' ')
-      matcher = negate ? be_false : be_true
-      page.evaluate_script(visibility_detecting_javascript).should matcher
+      matcher = negate ? false : true
+      page.evaluate_script(visibility_detecting_javascript).should eq(validity)
     end
   else
     invisibility_detecting_matcher = if tag
@@ -504,7 +504,7 @@ end
 # Example:
 #
 #       Then "Sponsor" should link to "http://makandra.com"
-# 
+#
 Then /^"([^"]*)" should link to "([^"]*)"$/ do |link_label, target|
   patiently do
     link = find_link(link_label)
@@ -624,7 +624,7 @@ Then /^the "([^\"]*)" field should( not)? be visible$/ do |label, negate|
             return(field.is(':visible'));
           })();
       ].gsub(/\n/, ' ')
-      page.evaluate_script(visibility_detecting_javascript).send(expectation, be_true)
+      page.evaluate_script(visibility_detecting_javascript).send(expectation, eq(true))
     end
   else
     field.send(expectation, be_visible)
@@ -638,7 +638,7 @@ When /^I wait for the page to load$/ do
   if [:selenium, :webkit, :poltergeist].include?(Capybara.current_driver)
     patiently do
       # when no jQuery is loaded, we assume there are no pending AJAX requests
-      page.evaluate_script("typeof jQuery === 'undefined' || $.active == 0").should be_true
+      page.evaluate_script("typeof jQuery === 'undefined' || $.active == 0").should eq(true)
     end
   end
   page.has_content? ''

--- a/lib/spreewald_support/custom_matchers.rb
+++ b/lib/spreewald_support/custom_matchers.rb
@@ -5,7 +5,7 @@ module CustomMatchers
     match do |field_value|
       @field_value = field_value.to_s
       @expected_string = expected_string
-      regex_parts = expected_string.split('*', -1).collect { |part| Regexp.escape(part) }
+      regex_parts = expected_string.to_s.split('*', -1).collect { |part| Regexp.escape(part) }
 
       @field_value =~ /\A#{regex_parts.join(".*")}\z/m
     end
@@ -18,5 +18,5 @@ module CustomMatchers
       "The field's content #{@field_value.inspect} matches #{@expected_string.inspect}"
     end
   end
-  
+
 end


### PR DESCRIPTION
This is a temporary measure. There's a pile of things that should be changed, but would require a lot more effort.

It may be worth considering doing all assertions through MiniTest as it's already bundled with Ruby, and doesn't impose yet another dependency upon a user of this gem.
