### PR TITLE
Add Minitest::Assertion to the error tolerance list of #patiently

### DIFF
--- a/lib/spreewald_support/tolerance_for_selenium_sync_issues.rb
+++ b/lib/spreewald_support/tolerance_for_selenium_sync_issues.rb
@@ -5,6 +5,7 @@ module ToleranceForSeleniumSyncIssues
     Capybara::ElementNotFound
     Spec::Expectations::ExpectationNotMetError
     RSpec::Expectations::ExpectationNotMetError
+    Minitest::Assertion
     Capybara::Poltergeist::ClickFailed
     Capybara::ExpectationNotMet
     Selenium::WebDriver::Error::StaleElementReferenceError


### PR DESCRIPTION
I'm using spreewald #patiently method.
But it doesn't work well with minitest.
If we just put Ministest::Assertion to ToleranceForSeleniumSyncIssues::RETRY_ERRORS makes it work well.
Meanwhile I'm using my branch with

``` ruby
group :test do
  # ...
  gem 'spreewald', :require => false, github: "abinoam/spreewald", branch: "feat_add_minitest_to_silently"
  gem 'minitest'
  # ...
end
```

I'm opening this pull request because perhaps you're interested in making spreewald #silently method to work with minitest.
