### PR TITLE
Fix deprecation warnings on Capybara 2.5

### DIFF
--- a/lib/spreewald_support/tolerance_for_selenium_sync_issues.rb
+++ b/lib/spreewald_support/tolerance_for_selenium_sync_issues.rb
@@ -16,11 +16,29 @@ module ToleranceForSeleniumSyncIssues
     Selenium::WebDriver::Error::JavascriptError
   ]
 
+  class CapybaraWrapper
+    def self.default_max_wait_time
+      if Capybara.respond_to?(:default_max_wait_time)
+        Capybara.default_max_wait_time
+      else
+        Capybara.default_wait_time
+      end
+    end
+
+    def self.default_max_wait_time=(value)
+      if Capybara.respond_to?(:default_max_wait_time=)
+        Capybara.default_max_wait_time = value
+      else
+        Capybara.default_wait_time = value
+      end
+    end
+  end
+
   # This is similiar but not entirely the same as Capybara::Node::Base#wait_until or Capybara::Session#wait_until
-  def patiently(seconds=Capybara.default_wait_time, &block)
-    old_wait_time = Capybara.default_wait_time
+  def patiently(seconds = CapybaraWrapper.default_max_wait_time, &block)
+    old_wait_time = CapybaraWrapper.default_max_wait_time
     # dont make nested wait_untils use up all the alloted time
-    Capybara.default_wait_time = 0 # for we are a jealous gem
+    CapybaraWrapper.default_max_wait_time = 0 # for we are a jealous gem
     if page.driver.wait?
       start_time = Time.now
       begin
@@ -36,7 +54,7 @@ module ToleranceForSeleniumSyncIssues
       block.call
     end
   ensure
-    Capybara.default_wait_time = old_wait_time
+    CapybaraWrapper.default_max_wait_time = old_wait_time
   end
 end
 


### PR DESCRIPTION
Capybara deprecated `.default_wait_time` in favor of `default_max_wait_time`