### PR TITLE
Added support for emails with attachments

### DIFF
--- a/lib/spreewald_support/mail_finder.rb
+++ b/lib/spreewald_support/mail_finder.rb
@@ -52,6 +52,8 @@ class MailFinder
             else
               part.decoded
             end
+          elsif part.content_type.include?('multipart/alternative')
+            part.parts.map(&:decoded)
           else
             part.decoded
           end

--- a/lib/spreewald_support/mail_finder.rb
+++ b/lib/spreewald_support/mail_finder.rb
@@ -58,7 +58,7 @@ class MailFinder
             part.decoded
           end
         }
-        utf8_parts = mail_bodies.select{ |part|
+        utf8_parts = mail_bodies.flatten.select{ |part|
           encoding = part.try(:encoding)
           encoding.nil? or # Ruby < 1.9.1
             encoding.name == 'UTF-8' # Ruby > 1.9.1


### PR DESCRIPTION
When sending email with attachment, method `email_text_body` fails with an error:

```
Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message. (NoMethodError)
```

This breaks `Then an email should have been sent with:` and `Then show me the emails` steps, and possibly others.

Email with attachment has 2 parts (attachment and multipart), and the second (multipart) part contains text and html parts.