### PR TITLE
Fix #99: 'I should see /REGEXP/' can now be composed with the 'within' step

### DIFF
--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -178,7 +178,7 @@ end.overridable
 Then /^(?:|I )should see \/([^\/]*)\/$/ do |regexp|
   regexp = Regexp.new(regexp)
   patiently do
-    expect(page).to have_xpath('//*', :text => regexp)
+    expect(page).to have_xpath('.//descendant-or-self::*', :text => regexp)
   end
 end.overridable
 
@@ -191,7 +191,7 @@ end.overridable
 Then /^(?:|I )should not see \/([^\/]*)\/$/ do |regexp|
   patiently do
     regexp = Regexp.new(regexp)
-    expect(page).to have_no_xpath('//*', :text => regexp)
+    expect(page).to have_no_xpath('.//descendant-or-self::*', :text => regexp)
   end
 end.overridable
 

--- a/tests/rails-3_capybara-1/Gemfile.lock
+++ b/tests/rails-3_capybara-1/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     spreewald (2.1.1)
       cucumber
       cucumber_priority (>= 0.3.0)
-      rspec
+      rspec (>= 2.13.0)
 
 GEM
   remote: https://rubygems.org/

--- a/tests/rails-3_capybara-2/Gemfile.lock
+++ b/tests/rails-3_capybara-2/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     spreewald (2.1.1)
       cucumber
       cucumber_priority (>= 0.3.0)
-      rspec
+      rspec (>= 2.13.0)
 
 GEM
   remote: https://rubygems.org/

--- a/tests/rails-4_capybara-3/Gemfile.lock
+++ b/tests/rails-4_capybara-3/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     spreewald (2.1.1)
       cucumber
       cucumber_priority (>= 0.3.0)
-      rspec
+      rspec (>= 2.13.0)
 
 GEM
   remote: https://rubygems.org/

--- a/tests/shared/app/views/static_pages/within.html.haml
+++ b/tests/shared/app/views/static_pages/within.html.haml
@@ -15,3 +15,11 @@
     %td All
 
 He lives within a few miles of Augsburg.
+
+.scoped-element
+  .scoped-element--child
+    Unique Text
+    Shared Text
+
+.unrelated-element
+  Shared Text

--- a/tests/shared/features/shared/web_steps.feature
+++ b/tests/shared/features/shared/web_steps.feature
@@ -191,6 +191,21 @@ Feature: Web steps
       And I should not see "Nonsense" within a table
 
 
+  Scenario: /^(?:|I )should see \/([^\/]*)\/$/
+    When I go to "/static_pages/within"
+    Then I should see /Shared Text/
+      And I should see /Unique Text/
+    But I should not see /Nonsense/
+
+
+  Scenario: /^(?:|I )should see \/([^\/]*)\/ within (.*[^:])$/
+    When I go to "/static_pages/within"
+    Then I should see /Shared Text/ within ".scoped-element"
+      And I should see /Shared Text/ within ".unrelated-element"
+      And I should see /Unique Text/ within ".scoped-element"
+    But I should not see /Unique Text/ within ".unrelated-element"
+
+
   Scenario: /^(.*) within (.*[^:])$/ with a Capybara::Node::Element
     When I go to "/static_pages/within"
     Then I should see "All" within the table row containing "Admin"


### PR DESCRIPTION
Fixes Issue: https://github.com/makandra/spreewald/issues/91

I initially propesed to use `.//*`, but this did not include the actual element specified with "within <foo>". `.//descendant-or-self::*` resolves this issue.