### PR TITLE
Allow 'I should see /REGEX/' to includes slashes, e.g. to match domains

### DIFF
--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -175,7 +175,7 @@ end.overridable
 # Checks that a regexp appears on the page
 #
 # Note that this does not detect if the text might be hidden via CSS
-Then /^(?:|I )should see \/([^\/]*)\/$/ do |regexp|
+Then /^(?:|I )should see \/(.*)\/$/ do |regexp|
   regexp = Regexp.new(regexp)
   patiently do
     expect(page).to have_xpath('.//descendant-or-self::*', :text => regexp)
@@ -188,7 +188,7 @@ Then /^(?:|I )should not see "([^"]*)"$/ do |text|
   end
 end.overridable
 
-Then /^(?:|I )should not see \/([^\/]*)\/$/ do |regexp|
+Then /^(?:|I )should not see \/(.*)\/$/ do |regexp|
   patiently do
     regexp = Regexp.new(regexp)
     expect(page).to have_no_xpath('.//descendant-or-self::*', :text => regexp)

--- a/tests/shared/app/views/static_pages/within.html.haml
+++ b/tests/shared/app/views/static_pages/within.html.haml
@@ -21,5 +21,9 @@ He lives within a few miles of Augsburg.
     Unique Text
     Shared Text
 
+  .hardly-matchable-texts
+    http://example.com
+    ^Will this text with special Regex characters match..?$
+
 .unrelated-element
   Shared Text

--- a/tests/shared/features/shared/web_steps.feature
+++ b/tests/shared/features/shared/web_steps.feature
@@ -195,7 +195,10 @@ Feature: Web steps
     When I go to "/static_pages/within"
     Then I should see /Shared Text/
       And I should see /Unique Text/
+      And I should see /http://example.com/
+      And I should see /\^Will this text with special Regex characters match\.\.\?\$/
     But I should not see /Nonsense/
+      And I should not see /http://other-domain.com/
 
 
   Scenario: /^(?:|I )should see \/([^\/]*)\/ within (.*[^:])$/
@@ -203,7 +206,10 @@ Feature: Web steps
     Then I should see /Shared Text/ within ".scoped-element"
       And I should see /Shared Text/ within ".unrelated-element"
       And I should see /Unique Text/ within ".scoped-element"
+      And I should see /http://example.com/ within ".hardly-matchable-texts"
+      And I should see /\^Will this text with special Regex characters match\.\.\?\$/ within ".hardly-matchable-texts"
     But I should not see /Unique Text/ within ".unrelated-element"
+      And I should not see /http://other-domain.com/ within ".unrelated-element"
 
 
   Scenario: /^(.*) within (.*[^:])$/ with a Capybara::Node::Element


### PR DESCRIPTION
Issue: https://github.com/makandra/spreewald/issues/88

This comes at the cost of using the wildcard matching group `(.*)` instead of `([^\/]*)`.. but I think the step is now more broadly usable, e.g. to match domains (`http://foo.bar`) and DateTimes (`03/10/19`).

I stumbled across the prior restriction multiple times during the last few months.