### PR TITLE
SWAT: [#159984366] Then the "something" button should be disabled

### DIFF
--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -662,18 +662,23 @@ When /^I switch to the new tab$/ do
   end
 end.overridable
 
-# Tests that an input or button with the given label is disabled.
+# Tests that an input, button or checkbox with the given label is disabled.
 Then /^the "([^\"]*)" (field|button|checkbox) should( not)? be disabled$/ do |label, kind, negate|
-  if kind == 'field' || kind == 'checkbox'
-    if Capybara::VERSION < "2.1"
-      element = find_field(label, :disabled => !negate)
+  if Gem::Version.new(Capybara::VERSION) < Gem::Version.new("2.1")
+    if kind == 'field' || kind == 'checkbox'
+      element = find_field(label)
     else
-      element = find_field(label, :disabled => !negate)
+      element = find_button(label)
     end
+    expect(element[:disabled]).send(negate ? :to : :not_to, eq(nil))
   else
-    element = find_button(label)
+    if kind == 'field' || kind == 'checkbox'
+      element = find_field(label, disabled: !negate)
+    else
+      element = find_button(label, disabled: !negate)
+    end
+    expect(element).to be_present
   end
-  expect(["false", "", nil]).send(negate ? :not_to : :to, include(element[:disabled]))
 end.overridable
 
 # Tests that a field with the given label is visible.

--- a/tests/shared/app/views/forms/disabled_elements.html.haml
+++ b/tests/shared/app/views/forms/disabled_elements.html.haml
@@ -1,0 +1,53 @@
+-# buttons
+%button(disabled='disabled')
+  Disabled button #1
+
+%button(disabled=true)
+  Disabled button #2
+
+%button(disabled='')
+  Disabled button #3
+
+%button(disabled='aaa')
+  Disabled button #4
+
+%button(disabled=false)
+  Enabled button #1
+
+%button
+  Enabled button #2
+
+-# checkboxes
+= form_tag do
+  - checked = false
+  = label_tag 'disabled_name_1', 'Disabled checkbox #1'
+  = check_box_tag 'disabled_name_1', 'value', checked, disabled: true
+
+  = label_tag 'disabled_name_2', 'Disabled checkbox #2'
+  = check_box_tag 'disabled_name_2', 'value', checked, disabled: ''
+
+  = label_tag 'disabled_name_3', 'Disabled checkbox #3'
+  = check_box_tag 'disabled_name_3', 'value', checked, disabled: 'aaa'
+
+  = label_tag 'enabled_name_1', 'Enabled checkbox #1'
+  = check_box_tag 'enabled_name_1', 'value', checked, disabled: false
+
+  = label_tag 'enabled_name_2', 'Enabled checkbox #2'
+  = check_box_tag 'enabled_name_2', 'value', checked
+
+-# fields
+= form_tag do
+  = label_tag 'disabled_field_1', 'Disabled field #1'
+  = text_field_tag 'disabled_field_1', 'value', disabled: true
+
+  = label_tag 'disabled_field_2', 'Disabled field #2'
+  = text_field_tag 'disabled_field_2', 'value', disabled: ''
+
+  = label_tag 'disabled_field_3', 'Disabled field #3'
+  = text_field_tag 'disabled_field_3', 'value', disabled: 'aaa'
+
+  = label_tag 'enabled_field_1', 'Enabled field #1'
+  = text_field_tag 'enabled_field_1', 'value', disabled: false
+
+  = label_tag 'enabled_field_2', 'Enabled field #2'
+  = text_field_tag 'enabled_field_2', 'value'

--- a/tests/shared/features/shared/web_steps.feature
+++ b/tests/shared/features/shared/web_steps.feature
@@ -268,3 +268,28 @@ Feature: Web steps
       And I should not see the number 60,72
       And I should not see the amount -60,7 €
       And I should not see the amount -10,000.99 EUR within ".unrelated-element"
+
+
+  Scenario: /^the "([^\"]*)" button should( not)? be disabled$/
+    When I go to "/forms/disabled_elements"
+    # buttons
+    Then the "Disabled button #1" button should be disabled
+      And the "Disabled button #2" button should be disabled
+      And the "Disabled button #3" button should be disabled
+      And the "Disabled button #4" button should be disabled
+    But the "Enabled button #1" button should not be disabled
+      And the "Enabled button #2" button should not be disabled
+
+      # checkboxes
+      And the "Disabled checkbox #1" checkbox should be disabled
+      And the "Disabled checkbox #2" checkbox should be disabled
+      And the "Disabled checkbox #3" checkbox should be disabled
+    But the "Enabled checkbox #1" checkbox should not be disabled
+      And the "Enabled checkbox #2" checkbox should not be disabled
+
+      # fields
+      And the "Disabled field #1" field should be disabled
+      And the "Disabled field #2" field should be disabled
+      And the "Disabled field #3" field should be disabled
+    But the "Enabled field #1" field should not be disabled
+      And the "Enabled field #2" field should not be disabled


### PR DESCRIPTION
In Capybara <2.1 erlauben  `find_field` und `find_button` nur ein Argument, daher war der Vorschlag von Emanuel nicht umsetzbar.

Habe die Änderungen zusätzlich in den Projekten just_claims, verkehrswacht und project_hero (capybara 1.1) getestet.