### PR TITLE
[bugfix] add rspec/matchers dependency

### DIFF
--- a/lib/spreewald/all_steps.rb
+++ b/lib/spreewald/all_steps.rb
@@ -1,4 +1,5 @@
 # coding: UTF-8
+require 'rspec/matchers'
 
 Dir[File.join(File.dirname(__FILE__), '*_steps.rb')].each do |f|
   name = File.basename(f, '.rb')


### PR DESCRIPTION
bug fix for error message `uninitialized constant RSpec::Matchers (NameError)`