### PR TITLE
Improve disabled steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Add radio buttons to the `the "..." (field|button|checkbox|radio button) should( not)? be disabled` step.
+- All web steps interacting with forms will now find both enabled and disabled fields.
+- Using the `and disabled` modifier of the `the "..." checkbox should( not)? be checked` step is now deprecated.
+
 ## 2.7.0
 - Add a step modifier to control different Capybara sessions: `... in the browser session "..."`. (see issue [#66](https://github.com/makandra/spreewald/issues/66))
 

--- a/README.md
+++ b/README.md
@@ -574,6 +574,8 @@ deprecation notice. Decide for yourself whether you want to use them:
 
 * **Then the "..." checkbox should( not)? be checked( and disabled)?**
 
+  Note: The `and disabled` modifier is deprecated and should not be used.
+
 
 * **Then the radio button "..." should( not)? be (checked|selected)**
 
@@ -680,7 +682,7 @@ deprecation notice. Decide for yourself whether you want to use them:
   
       Then "Sponsor" should link to "http://makandra.com/"
   
-  Don't forget the trailing slash. Otherwise you'll get the error 
+  Don't forget the trailing slash. Otherwise you'll get the error
     expected: /http:\/\/makandra.com(\?[^\/]*)?$/
          got: "http://makandra.com/" (using =~)
 
@@ -715,9 +717,9 @@ deprecation notice. Decide for yourself whether you want to use them:
 * **When I enter "..." into the browser dialog**
 
 
-* **Then the "..." (field|button|checkbox) should( not)? be disabled**
+* **Then the "..." (field|button|checkbox|radio button) should( not)? be disabled**
 
-  Tests that an input, button or checkbox with the given label is disabled.
+  Tests that an input, button, checkbox or radio button with the given label is disabled.
 
 
 * **Then the "..." field should( not)? be visible**

--- a/lib/spreewald_support/web_steps_helpers.rb
+++ b/lib/spreewald_support/web_steps_helpers.rb
@@ -1,3 +1,5 @@
+require 'spreewald_support/comparison'
+
 module WebStepsHelpers
 
   def assert_visible(options)
@@ -6,6 +8,21 @@ module WebStepsHelpers
 
   def assert_hidden(options)
     visibility_test(options.merge(:expectation => :hidden))
+  end
+
+  def find_with_disabled(*args, **options, &optional_filter_block)
+    if Spreewald::Comparison.compare_versions(Capybara::VERSION, :<, "2.0")
+      find(:xpath, XPath::HTML.send(args[0], args[1]))
+    elsif Spreewald::Comparison.compare_versions(Capybara::VERSION, :<, "2.6")
+      begin
+        find(*args, **options, disabled: true, &optional_filter_block)
+      rescue Capybara::ElementNotFound
+        find(*args, **options, disabled: false, &optional_filter_block)
+      end
+    else
+      options[:disabled] = :all
+      find(*args, **options, &optional_filter_block)
+    end
   end
 
   private

--- a/tests/shared/app/views/forms/disabled_elements.html.haml
+++ b/tests/shared/app/views/forms/disabled_elements.html.haml
@@ -51,3 +51,21 @@
 
   = label_tag 'enabled_field_2', 'Enabled field #2'
   = text_field_tag 'enabled_field_2', 'value'
+
+-# radio buttons
+= form_tag do
+  - selected = false
+  = label_tag 'disabled_radio_1', 'Disabled radio button #1'
+  = radio_button_tag 'disabled_radio', '1', selected, disabled: true
+
+  = label_tag 'disabled_radio_2', 'Disabled radio button #2'
+  = radio_button_tag 'disabled_radio', '2', selected, disabled: ''
+
+  = label_tag 'disabled_radio_3', 'Disabled radio button #3'
+  = radio_button_tag 'disabled_radio', '3', selected, disabled: 'aaa'
+
+  = label_tag 'enabled_radio_1', 'Enabled radio button #1'
+  = radio_button_tag 'enabled_radio', '1', selected, disabled: false
+
+  = label_tag 'enabled_radio_2', 'Enabled radio button #2'
+  = radio_button_tag 'enabled_radio', '2', selected

--- a/tests/shared/app/views/forms/form1.html.haml
+++ b/tests/shared/app/views/forms/form1.html.haml
@@ -3,6 +3,9 @@
   = label_tag 'text_control', 'Text control'
   = text_field_tag 'text_control', 'Text control value'
 
+  = label_tag 'disabled_text_control', 'Disabled text control'
+  = text_field_tag 'disabled_text_control', 'Disabled text control value', disabled: true
+
   = label_tag 'select_control', 'Select control'
   = select_tag 'select_control', options_for_select([['Label 1', 'value1'], ['Label 2', 'value2'], ['Label 3', 'value3']], 'value2')
 

--- a/tests/shared/features/shared/web_steps.feature
+++ b/tests/shared/features/shared/web_steps.feature
@@ -4,6 +4,7 @@ Feature: Web steps
     When I go to "/forms/form1"
     Then the "Text control" field should contain "Text control value"
     Then the "Text control" field should not contain "false text"
+    Then the "Disabled text control" field should contain "Disabled text control value"
     Then the "Select control" field should contain "Label 2"
     Then the "Select control without selection" field should contain "Label 1"
     Then the "Textarea control" field should contain "Textarea control value"
@@ -85,7 +86,7 @@ Feature: Web steps
   Scenario: /^I go back$/
     Given I go to "/static_pages/link_to_home"
       And I follow "Home"
-    
+
     When I go back
     Then I should be on "/static_pages/link_to_home"
 
@@ -341,6 +342,12 @@ Feature: Web steps
     But the "Enabled field #1" field should not be disabled
       And the "Enabled field #2" field should not be disabled
 
+      # radio buttons
+      And the "Disabled radio button #1" radio button should be disabled
+      And the "Disabled radio button #2" radio button should be disabled
+      And the "Disabled radio button #3" radio button should be disabled
+    But the "Enabled radio button #1" radio button should not be disabled
+      And the "Enabled radio button #2" radio button should not be disabled
 
   Scenario: /^the window should be titled "([^"]*)"$/
     When I go to "/static_pages/home"


### PR DESCRIPTION
Add a step to check for disabled radio buttons.
All web steps interacting with forms will now find both enabled and
disabled fields.
Closes #124