### PR TITLE
Improve form steps with disabled fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.0.0
+- All web steps interacting with forms will now find both enabled and disabled fields. This affects the following steps:
+  - `I should( not)? see a field "..."`
+  - `the "..." field should( not)? contain "..."`
+  - `I should see a form with the following values:`
+  - `the "..." field should have the error "..."`
+  - `the "..." field should( not)? have an error`
+  - `the "..." checkbox should( not)? be checked`
+  - `"..." should be selected for "..."`
+  - `nothing should be selected for "..."`
+  - `"..." should( not)? be an option for "..."`
+  - `the "..." field should( not)? be visible`
+  - `the "..." select should( not)? be sorted`
+- The `and disabled` modifier of the step `the "..." checkbox should( not)? be checked` has been removed. Use the step without the modifier together with the step `the "..." checkbox should be disabled` to achieve the old behavior.
+
 ## 2.8.0
 - Add radio buttons to the `the "..." (field|button|checkbox|radio button) should( not)? be disabled` step.
 

--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ deprecation notice. Decide for yourself whether you want to use them:
 * **Then the "..." field should have no error**
 
 
-* **Then the "..." checkbox should( not)? be checked( and disabled)?**
+* **Then the "..." checkbox should( not)? be checked?**
 
 
 * **Then the radio button "..." should( not)? be (checked|selected)**

--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -201,10 +201,10 @@ Then /^I should( not)? see a field "([^"]*)"$/ do |negate, name|
   expectation = negate ? :not_to : :to
   patiently do
     begin
-      # In old Capybaras find_field returns nil, so we assign it to `field`
-      field = find_field(name)
+      # In old Capybaras find returns nil, so we assign it to `field`
+      field = find_with_disabled(:field, name)
     rescue Capybara::ElementNotFound
-      # In Capybara 0.4+ #find_field raises an error instead of returning nil
+      # In Capybara 0.4+ #find raises an error instead of returning nil
       # We must explicitely reset the field variable from a previous patiently iteration
       field = nil
     end
@@ -327,7 +327,7 @@ end.overridable
 # Checks that an input field contains some value (allowing * as wildcard character)
 Then /^the "([^"]*)" field should (not )?contain "([^"]*)"$/ do |label, negate, expected_string|
   patiently do
-    field = find_field(label)
+    field = find_with_disabled(:field, label)
     field_value = case field.tag_name
     when 'select'
       options = field.all('option')
@@ -347,7 +347,7 @@ end.overridable
 # Checks that a multiline textarea contains some value (allowing * as wildcard character)
 Then(/^the "(.*?)" field should (not )?contain:$/) do |label, negate, expected_string|
   patiently do
-    field = find_field(label)
+    field = find_with_disabled(:field, label)
     expect(field.value.chomp).send(negate ? :not_to : :to, contain_with_wildcards(expected_string))
   end
 end.overridable
@@ -369,7 +369,7 @@ end.overridable
 # Checks that an input field was wrapped with a validation error
 Then /^the "([^"]*)" field should have the error "([^"]*)"$/ do |field, error_message|
   patiently do
-    element = find_field(field)
+    element = find_with_disabled(:field, field)
     classes = element.find(:xpath, '..')[:class].split(' ')
 
     form_for_input = element.find(:xpath, 'ancestor::form[1]')
@@ -390,7 +390,7 @@ end.overridable
 Then /^the "([^\"]*)" field should( not)? have an error$/ do |label, negate|
   patiently do
     expectation = negate ? :not_to : :to
-    field = find_field(label)
+    field = find_with_disabled(:field, label)
     expect(field[:id]).to be_present # prevent bad CSS selector if field lacks id
     expect(page).send(expectation, have_css(".field_with_errors ##{field[:id]}"))
   end
@@ -398,22 +398,18 @@ end.overridable
 
 Then /^the "([^"]*)" field should have no error$/ do |field|
   patiently do
-    element = find_field(field)
+    element = find_with_disabled(:field, field)
     classes = element.find(:xpath, '..')[:class].split(' ')
     expect(classes).not_to include('field_with_errors')
     expect(classes).not_to include('error')
   end
 end.overridable
 
-Then /^the "([^"]*)" checkbox should( not)? be checked( and disabled)?$/ do |label, negate, disabled|
+Then /^the "([^"]*)" checkbox should( not)? be checked?$/ do |label, negate|
   expectation = negate ? :not_to : :to
 
   patiently do
-    field = if Spreewald::Comparison.compare_versions(Capybara::VERSION, :<, "2.1")
-      find_field(label)
-    else
-      find_field(label, :disabled => !!disabled)
-    end
+    field = find_with_disabled(:field, label)
     expect(field).send expectation, be_checked
   end
 end.overridable
@@ -484,7 +480,7 @@ end.overridable
 
 Then /^nothing should be selected for "([^"]*)"$/ do |field|
   patiently do
-    select = find_field(field)
+    select = find_with_disabled(:field, field)
     begin
       selected_option = select.find(:xpath, ".//option[@selected = 'selected']") || select.all(:css, 'option').first
       value = selected_option ? selected_option.value : nil
@@ -504,11 +500,11 @@ Then /^"([^"]*)" should( not)? be an option for "([^"]*)"$/ do |value, negate, f
   patiently do
     if negate
       begin
-        expect(find_field(field)).to have_no_css(*finder_arguments)
+        expect(find_with_disabled(:field, field)).to have_no_css(*finder_arguments)
       rescue Capybara::ElementNotFound
       end
     else
-      expect(find_field(field)).to have_css(*finder_arguments)
+      expect(find_with_disabled(:field, field)).to have_css(*finder_arguments)
     end
   end
 end.overridable
@@ -689,11 +685,11 @@ end.overridable
 # Tests that a field with the given label is visible.
 Then /^the "([^\"]*)" field should( not)? be visible$/ do |label, hidden|
   if Spreewald::Comparison.compare_versions(Capybara::VERSION, :<, "2.1")
-    field = find_field(label)
+    field = find_with_disabled(:field, label)
   else
     # Capybara 2.1+ won't usually interact with hidden elements,
     # but we can override this behavior by passing { visible: false }
-    field = find_field(label, :visible => false)
+    field = find_with_disabled(:field, label, :visible => false)
   end
 
   selector = "##{field['id']}"
@@ -754,7 +750,7 @@ end.overridable
 # Tests whether a select field is sorted. Uses Array#natural_sort, if defined;
 # Array#sort else.
 Then /^the "(.*?)" select should( not)? be sorted$/ do |label, negate|
-  select = find_field(label)
+  select = find_with_disabled(:field, label)
   options = select.all('option').reject { |o| o.value.blank? }
   option_texts = options.collect(&:text)
 

--- a/tests/shared/app/views/forms/checkbox_form.html.haml
+++ b/tests/shared/app/views/forms/checkbox_form.html.haml
@@ -4,6 +4,9 @@
   = label_tag 'checked_name', 'Checked'
   = check_box_tag 'checked_name', 'value', checked
 
+  = label_tag 'checked_disabled_name', 'Checked disabled'
+  = check_box_tag 'checked_disabled_name', 'value', checked, disabled: true
+
   - checked = false
   = label_tag 'unchecked_name', 'Unchecked'
   = check_box_tag 'unchecked_name', 'value', checked

--- a/tests/shared/app/views/forms/disabled_elements.html.haml
+++ b/tests/shared/app/views/forms/disabled_elements.html.haml
@@ -69,3 +69,4 @@
 
   = label_tag 'enabled_radio_2', 'Enabled radio button #2'
   = radio_button_tag 'enabled_radio', '2', selected
+

--- a/tests/shared/app/views/forms/form1.html.haml
+++ b/tests/shared/app/views/forms/form1.html.haml
@@ -3,6 +3,9 @@
   = label_tag 'text_control', 'Text control'
   = text_field_tag 'text_control', 'Text control value'
 
+  = label_tag 'disabled_text_control', 'Disabled text control'
+  = text_field_tag 'disabled_text_control', 'Disabled text control value', disabled: true
+
   = label_tag 'select_control', 'Select control'
   = select_tag 'select_control', options_for_select([['Label 1', 'value1'], ['Label 2', 'value2'], ['Label 3', 'value3']], 'value2')
 

--- a/tests/shared/app/views/forms/invalid_form.html.haml
+++ b/tests/shared/app/views/forms/invalid_form.html.haml
@@ -5,6 +5,9 @@
   .form-group.field_with_errors
     = label_tag 'textarea_control_1', 'B is invalid'
     = text_area_tag 'textarea_control_1', "Textarea control line 1\nTextarea control line 2\n"
+  .form-group.field_with_errors
+    = label_tag 'disabled_control', 'Disabled is invalid'
+    = text_field_tag 'disabled_control', "Disabled control value", disabled: true
   .form-group
     = label_tag 'textarea_control_2', 'C'
     = text_area_tag 'textarea_control_2', "Textarea control line 1\nTextarea control line 2\n"

--- a/tests/shared/features/shared/web_steps.feature
+++ b/tests/shared/features/shared/web_steps.feature
@@ -4,6 +4,7 @@ Feature: Web steps
     When I go to "/forms/form1"
     Then the "Text control" field should contain "Text control value"
     Then the "Text control" field should not contain "false text"
+    Then the "Disabled text control" field should contain "Disabled text control value"
     Then the "Select control" field should contain "Label 2"
     Then the "Select control without selection" field should contain "Label 1"
     Then the "Textarea control" field should contain "Textarea control value"
@@ -35,12 +36,14 @@ Feature: Web steps
     When I go to "/forms/invalid_form"
     Then the "A" field should have an error
     Then the "B" field should have an error
+    Then the "Disabled" field should have an error
     Then the "C" field should not have an error
 
   Scenario: /^the "([^"]*)" field should have the error "([^"]*)"$/
     When I go to "/forms/invalid_form"
     Then the "A" field should have the error "is invalid"
     Then the "B" field should have the error "is invalid"
+    Then the "Disabled" field should have the error "is invalid"
 
 
   Scenario: /^the "([^"]*)" field should have no error$/
@@ -93,6 +96,7 @@ Feature: Web steps
   Scenario: /^the "([^"]*)" checkbox should( not)? be checked$/
     When I go to "/forms/checkbox_form"
     Then the "Checked" checkbox should be checked
+      And the "Checked disabled" checkbox should be checked
       And the "Unchecked" checkbox should not be checked
 
 
@@ -300,6 +304,12 @@ Feature: Web steps
       And I should see a link labeled "Also matches via the title attribute"
     But I should not see a link labeled "Nonexistent Link"
       And I should not see a link labeled "First visible link" within ".unrelated-element"
+
+
+  Scenario: /^I should( not)? see a field "([^"]*)"$/
+    When I go to "/forms/disabled_elements"
+    Then I should see a field "Enabled field #1"
+      And I should see a field "Disabled field #1"
 
 
   Scenario: /^I should( not)? see the (?:number|amount) ([\-\d,\.]+)(?: (.*?))?$/


### PR DESCRIPTION
All web steps interacting with forms will now find enabled and disabled
fields.
The `and disabled` modifier of the step `the "..." checkbox should(
not)? be checked` was removed.
Closes #124 