### PR TITLE
Update email steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- The step `an email should have been sent with:` does now support wildcards (`*` at the end of a line to ignore the rest of the line, `*` as single character in a line to ignore multiple lines). The step also has better error messages if an email could not be found.
+- The step `show me the emails` got an option to display only the email headers. Additionally, a new step `show me the email( header)?s with:` has been created to only show a subset of all sent emails, with a syntax similar to `an email should have been sent with:`.
+- The email steps `an email should have been sent (from ...) (to ...) (cc ...) ...`, `that email should( not)? have the following lines in the body` and `that email should have the following content in the body:` have been deprecated in favor of `an email should have been sent with:`.
+
 ## 2.8.0
 - Add radio buttons to the `the "..." (field|button|checkbox|radio button) should( not)? be disabled` step.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 2.9.0
 - The step `an email should have been sent with:` does now support wildcards (`*` at the end of a line to ignore the rest of the line, `*` as single character in a line to ignore multiple lines). The step also has better error messages if an email could not be found.
 - The step `show me the emails` got an option to display only the email headers. Additionally, a new step `show me the email( header)?s with:` has been created to only show a subset of all sent emails, with a syntax similar to `an email should have been sent with:`.
 - The email steps `an email should have been sent (from ...) (to ...) (cc ...) ...`, `that email should( not)? have the following lines in the body` and `that email should have the following content in the body:` have been deprecated in favor of `an email should have been sent with:`.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ the step definitions.
 * **When I clear my e?mails**
 
 
-* **Then (an|no) e?mail should have been sent with:**
+* **Then (an?|no)( HTML| plain-text|) e?mail should have been sent with:**
 
   Example:
   
@@ -225,24 +225,23 @@ the step definitions.
         From: max.mustermann@example.com
         Reply-To: mmuster@gmail.com
         To: john.doe@example.com
+        CC: jane.doe@example.com
+        BCC: johnny.doe@example.com
         Subject: The subject may contain "quotes"
-        Attachments: ...
+        Attachments: image.jpg, attachment.pdf
   
-        Message body goes here.
+        This is the message body. You can use * as a wildcard to omit the rest
+        of a line *
+        Or you can omit multiple lines if the asterisk is the only
+        character in a single line, like this:
+        *
+  
         """
   
-  You may skip lines in the header, of course. Note that the mail body is only checked for
-  _inclusion_. That means you can only test a prefix of the body. The subject may also be
-  a prefix.
-
-
-* **Then (an|no) e?mail should have been sent(( |and|with|from "..."|bcc "..."|cc "..."|to "..."|the subject "..."|the body "..."|the attachments "...")+)**
-
-  Example:
-  
-      Then an email should have been sent from "max.mustermann@example.com" to "john.doe@example.com" with bcc "john.wane@example.com" and with cc "foo@bar.com" and the subject "The subject" and the body "The body" and the attachments "attachment.pdf"
-  
-  You may skip parts, of course.
+  Because of backwards-compatibility, the body currently only has to be a prefix
+  of the real body. However, this is deprecated and will be removed in a future
+  version. Use wildcards instead.
+  You may skip lines in the header, of course.
 
 
 * **When I follow the (first|second|third)? link in the e?mail**
@@ -254,32 +253,20 @@ the step definitions.
 * **Then no e?mail should have been sent**
 
 
-* **Then I should see "..." in the e?mail**
+* **Then I should see "..." in the( HTML| plain-text|) e?mail**
 
   Checks that the last sent email includes some text
 
 
-* **Then show me the e?mails**
+* **Then show me the e?mail( header)?s**
 
-  Print all sent emails to STDOUT.
-
-
-* **Then that e?mail should( not)? have the following lines in the body:**
-
-  Example:
-  
-      And that mail should have the following lines in the body:
-        """
-        All of these lines
-        need to be present
-        """
-  
-  You may skip lines, of course. Note that you may also omit text at the end of each line.
+  Print all sent emails to STDOUT (optionally only the headers).
 
 
-* **Then that e?mail should have the following (|content in the )body:**
+* **Then show me the e?mail( header)?s with:**
 
-  Checks that the text should be included anywhere in the retrieved email body
+  Print a subset of all sent emails to STDOUT
+  This uses the same syntax as `Then an email should have been sent with:`
 
 
 ### file_attachment_steps.rb 

--- a/lib/spreewald_support/mail_finder.rb
+++ b/lib/spreewald_support/mail_finder.rb
@@ -5,22 +5,38 @@ class MailFinder
 
     attr_accessor :user_identity
 
-    def find(conditions)
+    def find(raw_data, type = '')
+      header, body = raw_data.split(/\n\n/, 2) # 2: maximum number of fields
+      conditions = {}
+      header.split("\n").each do |row|
+        if row.match(/^[A-Za-z\-]+: /i)
+          key, value = row.split(": ", 2)
+          conditions[key.strip.underscore.to_sym] = value.strip
+        end
+      end
+
       filename_method = Rails::VERSION::MAJOR < 3 ? 'original_filename' : 'filename'
-      ActionMailer::Base.deliveries.detect do |mail|
-        mail_body = email_text_body(mail)
+      matching_header = ActionMailer::Base.deliveries.select do |mail|
         [ conditions[:to].nil? || mail.to.include?(resolve_email conditions[:to]),
           conditions[:cc].nil? || mail.cc && mail.cc.include?(resolve_email conditions[:cc]),
           conditions[:bcc].nil? || mail.bcc && mail.bcc.include?(resolve_email conditions[:bcc]),
           conditions[:from].nil? || mail.from.include?(resolve_email conditions[:from]),
           conditions[:reply_to].nil? || mail.reply_to.include?(resolve_email conditions[:reply_to]),
           conditions[:subject].nil? || mail.subject.include?(conditions[:subject]),
-          conditions[:body].nil? || mail_body.include?(conditions[:body]),
           conditions[:attachments].nil? || conditions[:attachments].split(/\s*,\s*/).sort == Array(mail.attachments).collect(&:"#{filename_method}").sort
         ].all?
-      end.tap do |mail|
-        log(mail)
       end
+
+      matching_mails = if body
+        body_regex = expected_body_regex(body)
+        matching_header.select do |mail|
+          body_regex =~ email_text_body(mail, type).strip
+        end
+      else
+        matching_header
+      end
+
+      Results.new(matching_mails, matching_header, body_regex)
     end
 
     def resolve_email(identity)
@@ -31,46 +47,60 @@ class MailFinder
       end
     end
 
-    def log(mail)
-      if mail.present?
-        File.open("log/test_mails.log", "a") do |file|
-          file << "From: #{mail.from}\n"
-          file << "To: #{mail.to.join(', ')}\n" if mail.to
-          file << "Subject: #{mail.subject}\n\n"
-          file << email_text_body(mail)
-          file << "\n-------------------------\n\n"
-        end
-      end
+    def header_representation(mail)
+      header = ""
+      header << "From: #{mail.from}\n"
+      header << "Reply-To: #{mail.reply_to.join(', ')}\n" if mail.reply_to
+      header << "To: #{mail.to.join(', ')}\n" if mail.to
+      header << "CC: #{mail.cc.join(', ')}\n" if mail.cc
+      header << "BCC: #{mail.bcc.join(', ')}\n" if mail.bcc
+      header << "Subject: #{mail.subject}\n"
     end
 
-    def email_text_body(mail)
-      body = if mail.parts.any?
-        mail_bodies = mail.parts.map { |part|
-          if part.header.to_s.include?('Quoted-printable')
-            if Rails.version.starts_with?('2.3')
-              part.body.to_s
-            else
-              part.decoded
-            end
-          elsif part.content_type.include?('multipart/alternative')
-            part.parts.map(&:decoded)
-          else
-            part.decoded
-          end
-        }
-        utf8_parts = mail_bodies.flatten.select{ |part|
-          encoding = part.try(:encoding)
-          encoding.nil? or # Ruby < 1.9.1
-            encoding.name == 'UTF-8' # Ruby > 1.9.1
-        }
-        utf8_parts.join('\n')
-      elsif mail.body.respond_to? :raw_source
-        mail.body.raw_source
+    def email_text_body(mail, type = '')
+      if mail.html_part && type != 'plain-text'
+        dom = Nokogiri::HTML(mail.html_part.body.to_s)
+        dom.at_css('body').text.gsub(/\n\n/, "\n")
+      elsif mail.text_part && type != 'HTML'
+        mail.text_part.body.to_s
       else
-        mail.body
+        mail.body.to_s
       end
-      body.gsub("\r\n", "\n") # The mail gem (>= 2.7.1) switched from \n to \r\n line breaks (LF to CRLF) in plain text mails.
     end
 
+    def show_mails(mails, only_header = false)
+      message = ""
+      mails.each_with_index do |mail, i|
+        message << "E-Mail ##{i}\n"
+        message <<  "-" * 80 + "\n"
+        message << header_representation(mail)
+        message << "\n" + email_text_body(mail).strip + "\n" unless only_header
+        message <<  "-" * 80 + "\n\n"
+      end
+      message
+    end
+
+    def expected_body_regex(expected_body)
+      # To stay backwards-compatible, this will only check whether an email
+      # starts with the expected body.
+      expected = '\A\n' + Regexp.quote(expected_body.strip) + '\n\Z'
+      expected.gsub! '\n\*\n', '\n[\s\S]*\n'
+      expected.gsub! '\*\n', '.*\n'
+
+      expected.gsub! '\A\n', '\A'
+      expected.gsub! '\n\Z', '' # Change '' to '\Z' to force that the whole body matches
+
+      Regexp.new(expected)
+    end
+
+  end
+end
+
+class MailFinder::Results < Struct.new(:mails, :matching_header, :body_regex)
+  extend Forwardable
+  delegate [:size, :one?, :empty?] => :mails
+
+  def many?
+    size > 1
   end
 end

--- a/lib/spreewald_support/version.rb
+++ b/lib/spreewald_support/version.rb
@@ -1,3 +1,3 @@
 module Spreewald
-  VERSION = '2.8.0'
+  VERSION = '2.9.0'
 end

--- a/tests/rails-3_capybara-1/Gemfile.lock
+++ b/tests/rails-3_capybara-1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    spreewald (2.8.0)
+    spreewald (2.9.0)
       cucumber
       cucumber_priority (>= 0.3.0)
       rspec (>= 2.13.0)

--- a/tests/rails-3_capybara-2/Gemfile.lock
+++ b/tests/rails-3_capybara-2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    spreewald (2.8.0)
+    spreewald (2.9.0)
       cucumber
       cucumber_priority (>= 0.3.0)
       rspec (>= 2.13.0)

--- a/tests/rails-4_capybara-3/Gemfile.lock
+++ b/tests/rails-4_capybara-3/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    spreewald (2.8.0)
+    spreewald (2.9.0)
       cucumber
       cucumber_priority (>= 0.3.0)
       rspec (>= 2.13.0)

--- a/tests/rails-6_capybara-3/Gemfile.lock
+++ b/tests/rails-6_capybara-3/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    spreewald (2.8.0)
+    spreewald (2.9.0)
       cucumber
       cucumber_priority (>= 0.3.0)
       rspec (>= 2.13.0)

--- a/tests/shared/features/shared/email_steps.feature
+++ b/tests/shared/features/shared/email_steps.feature
@@ -1,10 +1,10 @@
 Feature: Test Spreewald's email steps
-  
+
   Scenario: /^no e?mail should have been sent$/
     When I go to "/emails/do_nothing"
     Then the following step should succeed:
       | no email should have been sent |
-  
+
     When I go to "/emails/send_email"
     Then the following step should fail:
       | no email should have been sent |
@@ -47,6 +47,53 @@ Feature: Test Spreewald's email steps
         with
         line
         breaks
+        '''
+      """
+
+    # Test with end-of-line wildcards
+    Then the following multiline step should succeed:
+      """
+      Then an email should have been sent with:
+        '''
+        From: from@example.com
+        Reply-To: reply-to@example.com
+        To: to@example.com
+        Subject: SUBJECT
+
+        Bo*
+        wi*
+        li*
+        br*
+        '''
+      """
+
+    # Test with multiple-line wildcards
+    Then the following multiline step should succeed:
+      """
+      Then an email should have been sent with:
+        '''
+        From: from@example.com
+        Reply-To: reply-to@example.com
+        To: to@example.com
+        Subject: SUBJECT
+
+        Body
+        *
+        breaks
+        '''
+      """
+
+    # Test with the whole body being a multiple-line wildcard
+    Then the following multiline step should succeed:
+      """
+      Then an email should have been sent with:
+        '''
+        From: from@example.com
+        Reply-To: reply-to@example.com
+        To: to@example.com
+        Subject: SUBJECT
+
+        *
         '''
       """
 
@@ -148,12 +195,29 @@ Feature: Test Spreewald's email steps
         with
         line
         breaks
-        
+
         MORE-BODY
         '''
       """
 
-  Scenario: /^(an|no) e?mail should have been sent((?: |and|with|from "[^"]+"|bcc "[^"]+"|cc "[^"]+"|to "[^"]+"|the subject "[^"]+"|the body "[^"]+"|the attachments "[^"]+")+)$/
+    # Test body with wildcard not at the end of a line
+    Then the following multiline step should fail:
+      """
+      Then an email should have been sent with:
+        '''
+        From: from@example.com
+        Reply-To: reply-to@example.com
+        To: to@example.com
+        Subject: SUBJECT
+
+        Body
+        *th
+        line
+        break
+        '''
+      """
+
+  Scenario: Scenario: /^(an|no) e?mail should have been sent((?: |and|with|from "[^"]+"|bcc "[^"]+"|cc "[^"]+"|to "[^"]+"|the subject "[^"]+"|the body "[^"]+"|the attachments "[^"]+")+)$/
     When I go to "/emails/send_email"
 
     # Test with correct conditions
@@ -181,7 +245,7 @@ Feature: Test Spreewald's email steps
         '''
       """
 
-     # Test with wrong body lines
+    # Test with wrong body lines
     Then the following multiline step should fail:
       """
       Then that email should have the following lines in the body:


### PR DESCRIPTION
The step `an email should have been sent with:` does now support wildcards (`*` at the end of a line to ignore the rest of the line, `*` as single character in a line to ignore multiple lines). The step also has better error messages if an email could not be found.

The step `show me the emails` got an option to display only the email headers. Additionally, a new step `show me the email( header)?s with:` has been created to only show a subset of all sent emails, with a syntax similar to `an email should have been sent with:`.

The email steps `an email should have been sent (from ...) (to ...) (cc ...) ...`, `that email should( not)? have the following lines in the body` and `that email should have the following content in the body:` have been deprecated in favor of `an email should have been sent with:`.

Closes #132