### PR TITLE
Fixes #161 Header indented lines matching

### DIFF
--- a/lib/spreewald_support/mail_finder.rb
+++ b/lib/spreewald_support/mail_finder.rb
@@ -7,10 +7,10 @@ class MailFinder
     attr_accessor :user_identity
 
     def find(raw_data, type = '')
-      header, body = raw_data.split(/\n\n/, 2) # 2: maximum number of fields
+      header, body = raw_data.split(/\n\n/, 2).map(&:strip_heredoc) # 2: maximum number of fields
       conditions = {}
       header.split("\n").each do |row|
-        if row.strip.match(/^[A-Za-z\-]+: /i)
+        if row.match(/^[A-Za-z\-]+: /i)
           key, value = row.split(": ", 2)
           conditions[key.strip.underscore.to_sym] = value.strip
         end

--- a/tests/shared/features/shared/email_steps.feature
+++ b/tests/shared/features/shared/email_steps.feature
@@ -50,6 +50,40 @@ Feature: Test Spreewald's email steps
         '''
       """
 
+    # Test with indented step lines
+    Then the following multiline step should succeed:
+      """
+      Then an email should have been sent with:
+        '''
+          From: from@example.com
+          Reply-To: reply-to@example.com
+          To: to@example.com
+          Subject: SUBJECT
+
+          Body
+          with
+          line
+          breaks
+        '''
+      """
+
+    # Test with indented body lines
+    Then the following multiline step should succeed:
+      """
+      Then an email should have been sent with:
+        '''
+        From: from@example.com
+        Reply-To: reply-to@example.com
+        To: to@example.com
+        Subject: SUBJECT
+
+          Body
+          with
+          line
+          breaks
+        '''
+      """
+
     # Test with body
     Then the following multiline step should succeed:
       """


### PR DESCRIPTION
By mapping `strip_heredoc` over header and body separately, both can be indented differently and strip_heredocs still unindents them correctly.
This change also makes the row.strip in line 13 unnecessary.