### PR TITLE
Open new tabs without an opener [fixes #174]

### DIFF
--- a/lib/spreewald/browser_tab_steps.rb
+++ b/lib/spreewald/browser_tab_steps.rb
@@ -19,7 +19,7 @@ When /^I open (.+?) in a new browser tab$/ do |page_name|
   previous_handles_count = browser.window_handles.size
   relative_target_path = path_to(page_name)
 
-  page.execute_script "window.open('#{relative_target_path}', '_blank')"
+  page.execute_script "window.open('#{relative_target_path}', '_blank', 'noopener')"
   step "there should be #{previous_handles_count + 1} browser tabs"
   step "I switch to the new browser tab"
 end.overridable


### PR DESCRIPTION
closes #174
see https://makandracards.com/makandra/501516-heads-up-window-open-couples-the-new-tab-to-its-opener