### PR TITLE
Ruby 2.7: Fix deprecation warning for using keyword arguments as last…

### DIFF
--- a/lib/spreewald/web_steps.rb
+++ b/lib/spreewald/web_steps.rb
@@ -486,18 +486,18 @@ end.overridable
 # Checks for the presence of an option in a select
 Then /^"([^"]*)" should( not)? be an option for "([^"]*)"$/ do |value, negate, field|
   finder_arguments = if Spreewald::Comparison.compare_versions(Capybara::VERSION, :<, "2.12")
-    ['option', { :text => value }]
+    { text: value }
   else
-    ['option', { :exact_text => value }]
+    { exact_text: value }
   end
   patiently do
     if negate
       begin
-        expect(find_with_disabled(:field, field)).to have_no_css(*finder_arguments)
+        expect(find_with_disabled(:field, field)).to have_no_css('option', **finder_arguments)
       rescue Capybara::ElementNotFound
       end
     else
-      expect(find_with_disabled(:field, field)).to have_css(*finder_arguments)
+      expect(find_with_disabled(:field, field)).to have_css('option', **finder_arguments)
     end
   end
 end.overridable


### PR DESCRIPTION
… argument

Fixes these deprecation warnings:
```
../.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spreewald-4.3.4/lib/spreewald/web_steps.rb:500:
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
../.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/capybara-3.36.0/lib/capybara/rspec/matchers.rb:51:
warning: The called method is defined here

../.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/spreewald-4.3.4/lib/spreewald/web_steps.rb:496:
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
../.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/capybara-3.36.0/lib/capybara/rspec/matchers.rb:165:
warning: The called method is defined here
```