### PR TITLE
Fix #205

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 4.6.0
+- Spreewald now explicitly depends on Capybara. We don't expect anyone used it without Capybara in the first place.
+- Changes to "the ... field should (not) have (an error|the error ...)" step:
+  - fixed an edgecases where errors were nested deeper inside a .field_with_errors element
+  - significant speed-up in most situations
+
 ## 4.5.1
 - Make `I should see an element for` and `I click on the element for` compatible for Ruby 3.0.  ([#204](https://github.com/makandra/spreewald/issues/204))
 

--- a/Gemfile.ruby266
+++ b/Gemfile.ruby266
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 ruby '2.6.6'
 
+gemspec
+
 gem 'rake'
 gem 'rspec'
 gem 'cucumber'

--- a/Gemfile.ruby266.lock
+++ b/Gemfile.ruby266.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spreewald (4.5.1)
+    spreewald (4.6.0)
       capybara
       cucumber
       cucumber_priority (>= 0.3.0)

--- a/Gemfile.ruby266.lock
+++ b/Gemfile.ruby266.lock
@@ -1,6 +1,18 @@
+PATH
+  remote: .
+  specs:
+    spreewald (4.5.1)
+      capybara
+      cucumber
+      cucumber_priority (>= 0.3.0)
+      rspec (>= 2.13.0)
+      xpath
+
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     aruba (2.0.0)
       bundler (>= 1.17, < 3.0)
       childprocess (>= 2.0, < 5.0)
@@ -9,6 +21,15 @@ GEM
       rspec-expectations (~> 3.4)
       thor (~> 1.0)
     builder (3.2.4)
+    capybara (3.36.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     childprocess (4.0.0)
     contracts (0.16.0)
     cucumber (7.1.0)
@@ -42,20 +63,30 @@ GEM
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
+    cucumber_priority (0.3.3)
+      cucumber
     diff-lcs (1.4.4)
     ffi (1.15.4)
     gemika (0.8.1)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    matrix (0.4.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.1115)
     mini_mime (1.1.2)
+    mini_portile2 (2.5.3)
     multi_test (0.1.2)
-    nokogiri (1.11.1-x86_64-linux)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    public_suffix (5.0.4)
     racc (1.5.2)
+    rack (3.0.8)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rake (13.0.3)
+    regexp_parser (2.8.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -72,6 +103,8 @@ GEM
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.1.0)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -84,6 +117,7 @@ DEPENDENCIES
   nokogiri
   rake
   rspec
+  spreewald!
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/Gemfile.ruby320
+++ b/Gemfile.ruby320
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 ruby '3.2.0'
 
+gemspec
+
 gem 'rake'
 gem 'rspec'
 gem 'cucumber'

--- a/Gemfile.ruby320.lock
+++ b/Gemfile.ruby320.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spreewald (4.5.1)
+    spreewald (4.6.0)
       capybara
       cucumber
       cucumber_priority (>= 0.3.0)

--- a/Gemfile.ruby320.lock
+++ b/Gemfile.ruby320.lock
@@ -1,6 +1,18 @@
+PATH
+  remote: .
+  specs:
+    spreewald (4.5.1)
+      capybara
+      cucumber
+      cucumber_priority (>= 0.3.0)
+      rspec (>= 2.13.0)
+      xpath
+
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.5)
+      public_suffix (>= 2.0.2, < 6.0)
     aruba (2.0.0)
       bundler (>= 1.17, < 3.0)
       childprocess (>= 2.0, < 5.0)
@@ -9,6 +21,15 @@ GEM
       rspec-expectations (~> 3.4)
       thor (~> 1.0)
     builder (3.2.4)
+    capybara (3.39.2)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     childprocess (4.0.0)
     contracts (0.16.0)
     cucumber (7.1.0)
@@ -42,6 +63,8 @@ GEM
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
+    cucumber_priority (0.3.3)
+      cucumber
     date (3.3.3)
     diff-lcs (1.4.4)
     ffi (1.15.4)
@@ -51,6 +74,7 @@ GEM
       net-imap
       net-pop
       net-smtp
+    matrix (0.4.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.1115)
@@ -67,8 +91,13 @@ GEM
       net-protocol
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
+    public_suffix (5.0.4)
     racc (1.5.2)
+    rack (3.0.8)
+    rack-test (2.1.0)
+      rack (>= 1.3)
     rake (13.0.3)
+    regexp_parser (2.8.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -86,6 +115,8 @@ GEM
       ffi (~> 1.1)
     thor (1.1.0)
     timeout (0.3.1)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   x86_64-linux
@@ -98,6 +129,7 @@ DEPENDENCIES
   nokogiri
   rake
   rspec
+  spreewald!
 
 RUBY VERSION
    ruby 3.2.0p0

--- a/lib/spreewald_support/capybara_wrapper.rb
+++ b/lib/spreewald_support/capybara_wrapper.rb
@@ -1,0 +1,19 @@
+module Spreewald
+  class CapybaraWrapper
+    def self.default_max_wait_time
+      if Capybara.respond_to?(:default_max_wait_time)
+        Capybara.default_max_wait_time
+      else
+        Capybara.default_wait_time
+      end
+    end
+
+    def self.default_max_wait_time=(value)
+      if Capybara.respond_to?(:default_max_wait_time=)
+        Capybara.default_max_wait_time = value
+      else
+        Capybara.default_wait_time = value
+      end
+    end
+  end
+end

--- a/lib/spreewald_support/field_errors.rb
+++ b/lib/spreewald_support/field_errors.rb
@@ -1,4 +1,5 @@
 require 'spreewald_support/driver_info'
+require 'spreewald_support/without_waiting'
 
 module Spreewald
   def self.field_error_class
@@ -21,6 +22,7 @@ module Spreewald
 
   class FieldErrorFinder
     include Spreewald::DriverInfo
+    include WithoutWaiting
 
     def initialize(page, element)
       @page = page
@@ -28,29 +30,50 @@ module Spreewald
     end
 
     def error_present?
-      custom_error? || bootstrap3_error? || bootstrap45_error? || rails_error?
+      without_waiting do
+        custom_error? || bootstrap3_error? || bootstrap45_error? || rails_error?
+      end
     end
 
     def custom_error?
-      Spreewald.field_error_class && @element.has_xpath?("ancestor-or-self::div[contains(@class, \"#{Spreewald.field_error_class}\")]")
+      return false unless Spreewald.field_error_class
+
+      has_xpath? do |x|
+        x.ancestor_or_self(:div)[x.attr(:class).contains_word(Spreewald.field_error_class)]
+      end
     end
 
     def bootstrap3_error?
-      @element.has_xpath?('ancestor::div[@class="form-group has-error"]')
+      has_xpath? do |x|
+        x.ancestor(:div)[x.attr(:class).contains_word('form-group')][x.attr(:class).contains_word('has-error')]
+      end
     end
 
     def bootstrap45_error?
-      element_classes = @element[:class] &.split(' ') || []
-      invalid_elements = if javascript_capable?
-        @page.all(':invalid') # Collect all invalid elements as Bootstrap 4 and 5 support client validation
-      end
+      without_waiting do
+        element_classes = @element[:class]&.split(' ') || []
+        invalid_elements = if javascript_capable?
+          @page.all(':invalid') # Collect all invalid elements as Bootstrap 4 and 5 support client validation
+        end
 
-      element_classes.include?('is-invalid') || (invalid_elements && invalid_elements.include?(@element))
+        element_classes.include?('is-invalid') || (invalid_elements && invalid_elements.include?(@element))
+      end
     end
 
     def rails_error?
-      parent_element_classes = @element.find(:xpath, '..')[:class] &.split(' ') || []
-      parent_element_classes.include?('field_with_errors')
+      has_xpath? do |x|
+        x.ancestor(:div)[x.attr(:class).contains_word('field_with_errors')]
+      end
     end
+
+    private
+
+    def has_xpath?(&block)
+      xpath = XPath.generate(&block)
+      without_waiting do
+        @element.has_xpath?(xpath)
+      end
+    end
+
   end
 end

--- a/lib/spreewald_support/tolerance_for_selenium_sync_issues.rb
+++ b/lib/spreewald_support/tolerance_for_selenium_sync_issues.rb
@@ -1,3 +1,5 @@
+require 'spreewald_support/capybara_wrapper'
+
 module ToleranceForSeleniumSyncIssues
   RETRY_ERRORS = %w[
     ActionController::UrlGenerationError
@@ -16,24 +18,6 @@ module ToleranceForSeleniumSyncIssues
     Selenium::WebDriver::Error::UnknownError
     Selenium::WebDriver::Error::NoSuchAlertError
   ]
-
-  class CapybaraWrapper
-    def self.default_max_wait_time
-      if Capybara.respond_to?(:default_max_wait_time)
-        Capybara.default_max_wait_time
-      else
-        Capybara.default_wait_time
-      end
-    end
-
-    def self.default_max_wait_time=(value)
-      if Capybara.respond_to?(:default_max_wait_time=)
-        Capybara.default_max_wait_time = value
-      else
-        Capybara.default_wait_time = value
-      end
-    end
-  end
 
   class Patiently
     WAIT_PERIOD = 0.05
@@ -68,7 +52,7 @@ module ToleranceForSeleniumSyncIssues
   end
 
 
-  def patiently(seconds = CapybaraWrapper.default_max_wait_time, &block)
+  def patiently(seconds = Spreewald::CapybaraWrapper.default_max_wait_time, &block)
     if page.driver.wait?
       Patiently.new.patiently(seconds, &block)
     else

--- a/lib/spreewald_support/version.rb
+++ b/lib/spreewald_support/version.rb
@@ -1,3 +1,3 @@
 module Spreewald
-  VERSION = '4.5.1'
+  VERSION = '4.6.0'
 end

--- a/lib/spreewald_support/without_waiting.rb
+++ b/lib/spreewald_support/without_waiting.rb
@@ -1,0 +1,13 @@
+require 'spreewald_support/capybara_wrapper'
+
+module Spreewald
+  module WithoutWaiting
+    def without_waiting
+      prior_max_wait_time = CapybaraWrapper.default_max_wait_time
+      CapybaraWrapper.default_max_wait_time = 0
+      yield
+    ensure
+      CapybaraWrapper.default_max_wait_time = prior_max_wait_time
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ Bundler.setup
 
 require 'pathname'
 
+require 'capybara'
+
 Dir[Pathname.new(__FILE__).join('..', 'support', '**', '*.rb')].each { |f| require f }
 
 

--- a/spec/spreewald_support/tolerance_for_selenium_sync_issues_spec.rb
+++ b/spec/spreewald_support/tolerance_for_selenium_sync_issues_spec.rb
@@ -1,13 +1,5 @@
 require 'spreewald_support/tolerance_for_selenium_sync_issues'
 
-module Capybara
-  class ElementNotFound < StandardError; end
-
-  class << self
-    attr_accessor :default_max_wait_time
-  end
-end
-
 describe ToleranceForSeleniumSyncIssues do
   subject { World.new }
   let(:wait_time) { 0.2 }

--- a/spec/spreewald_support/without_waiting_spec.rb
+++ b/spec/spreewald_support/without_waiting_spec.rb
@@ -1,0 +1,41 @@
+require 'spreewald_support/without_waiting'
+
+describe Spreewald::WithoutWaiting do
+
+  subject do
+    Class.new do
+      include Spreewald::WithoutWaiting
+    end.new
+  end
+
+  describe '#without_waiting' do
+    it 'calls the block while setting the Capybara wait time to 0' do
+      wait_time_in_block = nil
+      subject.without_waiting do
+        wait_time_in_block = Capybara.default_max_wait_time
+      end
+      expect(wait_time_in_block).to eq(0)
+    end
+
+    it 'resets the prior wait time' do
+      prior = Capybara.default_max_wait_time
+      Capybara.default_max_wait_time = 4
+      subject.without_waiting {}
+      expect(Capybara.default_max_wait_time).to eq(4)
+      Capybara.default_max_wait_time = prior
+    end
+
+    it 'resets the prior wait time on exceptions' do
+      prior = Capybara.default_max_wait_time
+      Capybara.default_max_wait_time = 4
+      expect do
+        subject.without_waiting do
+          raise 'error'
+        end
+      end.to raise_error('error')
+      expect(Capybara.default_max_wait_time).to eq(4)
+      Capybara.default_max_wait_time = prior
+    end
+  end
+
+end

--- a/spreewald.gemspec
+++ b/spreewald.gemspec
@@ -26,13 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('cucumber')
   gem.add_dependency('cucumber_priority', '>=0.3.0')
   gem.add_dependency('rspec', '>= 2.13.0')
-
-  # Development
-  gem.add_development_dependency 'bundler', '~> 1.11'
-  gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'pry'
-
-  # Testing
-  gem.add_development_dependency 'aruba', '~> 0.10.2'
-  gem.add_development_dependency 'geordi'
+  gem.add_dependency('capybara')
+  gem.add_dependency('xpath')
 end

--- a/tests/rails-7_capybara-3/Gemfile.lock
+++ b/tests/rails-7_capybara-3/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    spreewald (4.5.1)
+    spreewald (4.6.0)
       capybara
       cucumber
       cucumber_priority (>= 0.3.0)

--- a/tests/rails-7_capybara-3/Gemfile.lock
+++ b/tests/rails-7_capybara-3/Gemfile.lock
@@ -2,9 +2,11 @@ PATH
   remote: ../..
   specs:
     spreewald (4.5.1)
+      capybara
       cucumber
       cucumber_priority (>= 0.3.0)
       rspec (>= 2.13.0)
+      xpath
 
 GEM
   remote: https://rubygems.org/

--- a/tests/shared/app/views/forms/invalid_rails_form.html.haml
+++ b/tests/shared/app/views/forms/invalid_rails_form.html.haml
@@ -11,3 +11,7 @@
   .form-group
     = label_tag 'textarea_control_2', 'C'
     = text_area_tag 'textarea_control_2', "Textarea control line 1\nTextarea control line 2\n"
+  .field_with_errors
+    .form-group
+      = label_tag 'textarea_control_3', 'Nested field is invalid'
+      = text_area_tag 'textarea_control_3', "Textarea control line 1\nTextarea control line 2\n"

--- a/tests/shared/features/shared/web_steps.feature
+++ b/tests/shared/features/shared/web_steps.feature
@@ -35,53 +35,55 @@ Feature: Web steps
   Scenario: /^the "([^\"]*)" field should( not)? have an error$/
     When I go to "/forms/invalid_rails_form"
     Then the "A" field should have an error
-    Then the "B" field should have an error
-    Then the "Disabled" field should have an error
-    Then the "C" field should not have an error
+      And the "B" field should have an error
+      And the "Disabled" field should have an error
+      And the "C" field should not have an error
+      And the "Nested field" field should have an error
 
     When I go to "/forms/invalid_bootstrap3_form"
     Then the "A" field should have an error
-    Then the "B" field should have an error
-    Then the "Disabled" field should have an error
-    Then the "C" field should not have an error
+      And the "B" field should have an error
+      And the "Disabled" field should have an error
+      And the "C" field should not have an error
 
     When I go to "/forms/invalid_bootstrap4_form"
     Then the "A" field should have an error
-    Then the "B" field should have an error
-    Then the "Disabled" field should have an error
-    Then the "C" field should not have an error
+      And the "B" field should have an error
+      And the "Disabled" field should have an error
+      And the "C" field should not have an error
 
     When I set the custom field error class to "my-error"
       And I go to "/forms/invalid_custom_form"
     Then the "A" field should have an error
-    Then the "B" field should have an error
-    Then the "Disabled" field should have an error
-    Then the "C" field should not have an error
+      And the "B" field should have an error
+      And the "Disabled" field should have an error
+      And the "C" field should not have an error
 
 
   @javascript @field_errors
   Scenario: /^the "([^"]*)" field should have the error "([^"]*)"$/
     When I go to "/forms/invalid_rails_form"
     Then the "A" field should have the error "is invalid"
-    Then the "B" field should have the error "is invalid"
-    Then the "Disabled" field should have the error "is invalid"
+      And the "B" field should have the error "is invalid"
+      And the "Disabled" field should have the error "is invalid"
+      And the "Nested field" field should have an error
 
     When I go to "/forms/invalid_bootstrap3_form"
     Then the "A" field should have the error "is invalid"
-    Then the "B" field should have the error "is invalid"
-    Then the "Disabled" field should have the error "is invalid"
+      And the "B" field should have the error "is invalid"
+      And the "Disabled" field should have the error "is invalid"
 
     When I go to "/forms/invalid_bootstrap4_form"
     Then the "A" field should have the error "is invalid"
-    Then the "B" field should have the error "is invalid"
-    Then the "Disabled" field should have the error "is invalid"
+      And the "B" field should have the error "is invalid"
+      And the "Disabled" field should have the error "is invalid"
 
     When I set the custom field error class to "my-error"
       And I set the custom error message xpath to "parent::*/child::*[contains(@class, "my-error-description")]"
       And I go to "/forms/invalid_custom_form"
-    Then the "A" field should have the error "is invalid"
-    Then the "B" field should have the error "is invalid"
-    Then the "Disabled" field should have the error "is invalid"
+      And the "A" field should have the error "is invalid"
+      And the "B" field should have the error "is invalid"
+      And the "Disabled" field should have the error "is invalid"
 
   Scenario: /^I should see a form with the following values:$/
     When I go to "/forms/form1"


### PR DESCRIPTION
See #205.

Sped up the `FieldErrorFinder` significantly by setting Capybara.default_max_wait_time to 0. We are always called inside a patiently block anyways.