### PR TITLE
Fix undefined method 'irb_at_exit' in new IRB versions

### DIFF
--- a/lib/spreewald/development_steps.rb
+++ b/lib/spreewald/development_steps.rb
@@ -41,7 +41,7 @@ Then 'console' do
       irb.eval_input
     end
   ensure
-    IRB.irb_at_exit
+    IRB.conf[:AT_EXIT].each{ |hook| hook.call }
   end
 end.overridable
 


### PR DESCRIPTION
The development step 'Then console' does not work as intended for IRB >= 1.6.4.

When trying to exit the IRB console with `exit` you receive the error ```undefined method `irb_at_exit' for IRB:Module (NoMethodError)``` and the feature does no progress any further and fails.

IRB removes `irb_at_exit` as part of release [1.6.4](https://github.com/ruby/irb/releases/tag/v1.6.4) in a [dead code clean up commit](https://github.com/ruby/irb/commit/7de0234325a3b9e016c6990ddfd03dddbc77b8a4).
The method itself hasn't been used since [this commit](https://github.com/ruby/irb/commit/aaf4eb4e9830ae71240ca5d2047c5e3ad20a4044).

My change makes it work with old and new IRB versions.